### PR TITLE
INTYG-7882: Fixed erroneous statistics sent log

### DIFF
--- a/web/src/main/java/se/inera/intyg/intygstjanst/web/service/MonitoringLogService.java
+++ b/web/src/main/java/se/inera/intyg/intygstjanst/web/service/MonitoringLogService.java
@@ -23,17 +23,29 @@ import se.inera.intyg.schemas.contract.Personnummer;
 public interface MonitoringLogService {
 
     void logCertificateRegistered(String certificateId, String certificateType, String careUnit);
+
     void logCertificateSent(String certificateId, String certificateType, String careUnit, String recipient);
+
     void logCertificateRevoked(String certificateId, String certificateType, String careUnit);
+
     void logCertificateRevokeSent(String certificateId, String certificateType, String careUnit, String recipientId);
+
     void logCertificateListedByCitizen(Personnummer citizenId);
+
     void logCertificateListedByCare(Personnummer citizenId);
+
     void logCertificateStatusChanged(String certificateId, String status);
+
     void logStatisticsCreated(String certificateId, String certificateType, String careUnit);
-    void logStatisticsSent(String certificateId, String certificateType, String careUnit);
+
+    void logStatisticsSent(String certificateId, String certificateType, String careUnit, String recipient);
+
     void logStatisticsRevoked(String certificateId, String certificateType, String careUnit);
+
     void logStatisticsMessageSent(String certificateId, String topic);
+
     void logSendMessageToCareReceived(String messageId, String careUnit);
+
     void logSendMessageToRecipient(String messageId, String recipient);
 
     void logApprovedReceiversRegistered(String receivers, String intygsId);

--- a/web/src/main/java/se/inera/intyg/intygstjanst/web/service/impl/MonitoringLogServiceImpl.java
+++ b/web/src/main/java/se/inera/intyg/intygstjanst/web/service/impl/MonitoringLogServiceImpl.java
@@ -22,9 +22,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
-import se.inera.intyg.schemas.contract.Personnummer;
 import se.inera.intyg.common.util.logging.LogMarkers;
 import se.inera.intyg.intygstjanst.web.service.MonitoringLogService;
+import se.inera.intyg.schemas.contract.Personnummer;
 
 @Service
 public class MonitoringLogServiceImpl implements MonitoringLogService {
@@ -75,8 +75,8 @@ public class MonitoringLogServiceImpl implements MonitoringLogService {
     }
 
     @Override
-    public void logStatisticsSent(String certificateId, String certificateType, String careUnit) {
-        logEvent(MonitoringEvent.STATISTICS_SENT, certificateId, certificateType, careUnit);
+    public void logStatisticsSent(String certificateId, String certificateType, String careUnit, String recipient) {
+        logEvent(MonitoringEvent.STATISTICS_SENT, certificateId, certificateType, careUnit, recipient);
     }
 
     @Override
@@ -121,7 +121,7 @@ public class MonitoringLogServiceImpl implements MonitoringLogService {
         CERTIFICATE_LISTED_BY_CARE("Certificates for citizen '{}' - listed by care"),
         CERTIFICATE_STATUS_CHANGED("Certificate '{}' - changed to status '{}'"),
         STATISTICS_CREATED("Certificate '{}' with type '{}', care unit '{}' - sent to statistics"),
-        STATISTICS_SENT("Certificate '{}' with type '{}', care unit '{}' - sent to statistics"),
+        STATISTICS_SENT("Certificate '{}' with type '{}', care unit '{}', sent to '{}' - sent to statistics"),
         STATISTICS_REVOKED("Certificate '{}' with type '{}', care unit '{}' - revoke sent to statistics"),
         STATISTICS_MESSAGE_SENT("Message with topic '{}' for certificate '{}' - sent to statistics"),
         SEND_MESSAGE_TO_CARE_RECEIVED("Message with id '{}', care unit recipient '{}' - was received and forwarded to its recipient."),

--- a/web/src/main/java/se/inera/intyg/intygstjanst/web/service/impl/StatisticsServiceImpl.java
+++ b/web/src/main/java/se/inera/intyg/intygstjanst/web/service/impl/StatisticsServiceImpl.java
@@ -18,8 +18,11 @@
  */
 package se.inera.intyg.intygstjanst.web.service.impl;
 
+import static java.lang.invoke.MethodHandles.lookup;
+
 import javax.jms.Queue;
 import javax.jms.TextMessage;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,11 +31,9 @@ import org.springframework.jms.JmsException;
 import org.springframework.jms.core.JmsTemplate;
 import org.springframework.jms.core.MessageCreator;
 import org.springframework.stereotype.Service;
+
 import se.inera.intyg.intygstjanst.web.service.MonitoringLogService;
 import se.inera.intyg.intygstjanst.web.service.StatisticsService;
-
-
-import static java.lang.invoke.MethodHandles.lookup;
 
 @Service
 public class StatisticsServiceImpl implements StatisticsService {
@@ -98,7 +99,7 @@ public class StatisticsServiceImpl implements StatisticsService {
             rc = sendIntygDataPointToStatistik(SENT, null, certificateId, certificateType, recipientId);
         }
         if (rc) {
-            monitoringLogService.logCertificateSent(certificateId, certificateType, careUnitId, recipientId);
+            monitoringLogService.logStatisticsSent(certificateId, certificateType, careUnitId, recipientId);
         }
         return rc;
     }
@@ -126,8 +127,7 @@ public class StatisticsServiceImpl implements StatisticsService {
                 certificateXml,
                 certificateId,
                 certificateType,
-                null
-        );
+                null);
     }
 
     private boolean sendIntygDataPointToStatistik(

--- a/web/src/test/java/se/inera/intyg/intygstjanst/web/service/impl/MonitoringLogServiceImplTest.java
+++ b/web/src/test/java/se/inera/intyg/intygstjanst/web/service/impl/MonitoringLogServiceImplTest.java
@@ -18,6 +18,10 @@
  */
 package se.inera.intyg.intygstjanst.web.service.impl;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.verify;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -35,10 +39,6 @@ import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.Appender;
 import se.inera.intyg.intygstjanst.web.service.MonitoringLogService;
 import se.inera.intyg.schemas.contract.Personnummer;
-
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
 public class MonitoringLogServiceImplTest {
@@ -123,7 +123,8 @@ public class MonitoringLogServiceImplTest {
     public void shouldLogCertificateListedByCare() {
         final Personnummer citizenId = createPnr(CITIZEN);
         logService.logCertificateListedByCare(citizenId);
-        verifyLog(Level.INFO, "CERTIFICATE_LISTED_BY_CARE Certificates for citizen '" + citizenId.getPersonnummerHash() + "' - listed by care");
+        verifyLog(Level.INFO,
+                "CERTIFICATE_LISTED_BY_CARE Certificates for citizen '" + citizenId.getPersonnummerHash() + "' - listed by care");
     }
 
     @Test
@@ -141,9 +142,9 @@ public class MonitoringLogServiceImplTest {
 
     @Test
     public void shouldLogStatisticsSent() {
-        logService.logStatisticsSent(CERTIFICATE_ID, CERTIFICATE_TYPE, CARE_UNIT);
+        this.logService.logStatisticsSent(CERTIFICATE_ID, CERTIFICATE_TYPE, CARE_UNIT, RECIPIENT);
         verifyLog(Level.INFO,
-                "STATISTICS_SENT Certificate 'CERTIFICATE_ID' with type 'CERTIFICATE_TYPE', care unit 'CARE_UNIT' - sent to statistics");
+                "STATISTICS_SENT Certificate 'CERTIFICATE_ID' with type 'CERTIFICATE_TYPE', care unit 'CARE_UNIT', sent to 'RECIPIENT' - sent to statistics");
     }
 
     @Test

--- a/web/src/test/java/se/inera/intyg/intygstjanst/web/service/impl/StatisticsServiceImplTest.java
+++ b/web/src/test/java/se/inera/intyg/intygstjanst/web/service/impl/StatisticsServiceImplTest.java
@@ -18,10 +18,17 @@
  */
 package se.inera.intyg.intygstjanst.web.service.impl;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
 import javax.jms.JMSException;
 import javax.jms.Queue;
 import javax.jms.Session;
 import javax.jms.TextMessage;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -32,23 +39,10 @@ import org.springframework.jms.JmsException;
 import org.springframework.jms.core.JmsTemplate;
 import org.springframework.jms.core.MessageCreator;
 import org.springframework.test.util.ReflectionTestUtils;
+
 import se.inera.intyg.intygstjanst.persistence.model.dao.Certificate;
 import se.inera.intyg.intygstjanst.persistence.model.dao.OriginalCertificate;
 import se.inera.intyg.intygstjanst.web.service.MonitoringLogService;
-
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.only;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
-import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class StatisticsServiceImplTest {
@@ -135,7 +129,7 @@ public class StatisticsServiceImplTest {
         verify(message).setStringProperty(eq("certificate-id"), eq(id));
         verify(message).setStringProperty(eq("certificate-type"), eq(type));
         verify(message).setStringProperty(eq("certificate-recipient"), eq(recipient));
-        verify(monitoringLogService, only()).logCertificateSent(id, type, unit, recipient);
+        verify(monitoringLogService, only()).logStatisticsSent(id, type, unit, recipient);
 
     }
 


### PR DESCRIPTION
Vi ansåg att loggningen skedde med fel meddelande när det gällde intyg som skickas till mottagare i förhållande till statistiktjänsten.