### PR TITLE
INTYGFV-12452: Harmonization of logback file usage and structure

### DIFF
--- a/devops/openshift/test/config/logback-ocp.xml
+++ b/devops/openshift/test/config/logback-ocp.xml
@@ -24,8 +24,8 @@
 
     <include resource="logback-ocp-base.xml"/>
 
+    <logger name="se.inera.intyg.intygstjanst" level="warn" />
     <logger name="se.inera.intyg.intygstjanst.web.integration" level="info" />
-
     <logger name="se.inera.intyg.intygstjanst.web.service.impl.StatisticsServiceImpl" level="info" />
 
     <logger name="se.inera.intyg.intygstjanst.web.service.MonitoringLogService" level="info" additivity="false">

--- a/web/build.gradle
+++ b/web/build.gradle
@@ -25,7 +25,7 @@ gretty {
     debugSuspend = false
 
     jvmArgs = [
-            "-Dlogback.file=classpath:logback-ocp.xml",
+            "-Dlogback.file=classpath:logback-dev.xml",
             "-Dspring.profiles.active=" + springProfiles,
             "-Dcatalina.base=${buildDir}/catalina.base",
             "-Drecipient.config.file=${projectDir}/recipients-dev.json",

--- a/web/src/main/java/se/inera/intyg/intygstjanst/web/integration/RegisterCertificateResponderImpl.java
+++ b/web/src/main/java/se/inera/intyg/intygstjanst/web/integration/RegisterCertificateResponderImpl.java
@@ -48,7 +48,7 @@ import se.inera.intyg.common.support.modules.support.api.ModuleApi;
 import se.inera.intyg.common.support.modules.support.api.ModuleContainerApi;
 import se.inera.intyg.common.support.modules.support.api.dto.CertificateRelation;
 import se.inera.intyg.common.support.modules.support.api.dto.ValidateXmlResponse;
-import se.inera.intyg.common.util.logging.LogMarkers;
+import se.inera.intyg.infra.monitoring.logging.LogMarkers;
 import se.inera.intyg.infra.integration.pu.model.PersonSvar;
 import se.inera.intyg.infra.integration.pu.model.PersonSvar.Status;
 import se.inera.intyg.infra.integration.pu.services.PUService;

--- a/web/src/main/java/se/inera/intyg/intygstjanst/web/integration/RevokeMedicalCertificateResponderImpl.java
+++ b/web/src/main/java/se/inera/intyg/intygstjanst/web/integration/RevokeMedicalCertificateResponderImpl.java
@@ -37,7 +37,7 @@ import se.inera.intyg.common.support.integration.module.exception.CertificateRev
 import se.inera.intyg.common.support.integration.module.exception.InvalidCertificateException;
 import se.inera.intyg.common.support.model.CertificateState;
 import se.inera.intyg.common.support.validate.CertificateValidationException;
-import se.inera.intyg.common.util.logging.LogMarkers;
+import se.inera.intyg.infra.monitoring.logging.LogMarkers;
 import se.inera.intyg.infra.monitoring.annotation.PrometheusTimeMethod;
 import se.inera.intyg.intygstjanst.persistence.model.dao.Certificate;
 import se.inera.intyg.intygstjanst.persistence.model.dao.CertificateStateHistoryEntry;

--- a/web/src/main/java/se/inera/intyg/intygstjanst/web/integration/SendMedicalCertificateResponderImpl.java
+++ b/web/src/main/java/se/inera/intyg/intygstjanst/web/integration/SendMedicalCertificateResponderImpl.java
@@ -36,7 +36,7 @@ import se.inera.intyg.common.support.integration.module.exception.CertificateRev
 import se.inera.intyg.common.support.integration.module.exception.InvalidCertificateException;
 import se.inera.intyg.common.support.modules.support.api.exception.ExternalServiceCallException;
 import se.inera.intyg.common.support.validate.CertificateValidationException;
-import se.inera.intyg.common.util.logging.LogMarkers;
+import se.inera.intyg.infra.monitoring.logging.LogMarkers;
 import se.inera.intyg.infra.monitoring.annotation.PrometheusTimeMethod;
 import se.inera.intyg.intygstjanst.persistence.model.dao.Certificate;
 import se.inera.intyg.intygstjanst.web.exception.RecipientUnknownException;

--- a/web/src/main/java/se/inera/intyg/intygstjanst/web/service/impl/MonitoringLogServiceImpl.java
+++ b/web/src/main/java/se/inera/intyg/intygstjanst/web/service/impl/MonitoringLogServiceImpl.java
@@ -21,7 +21,7 @@ package se.inera.intyg.intygstjanst.web.service.impl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
-import se.inera.intyg.common.util.logging.LogMarkers;
+import se.inera.intyg.infra.monitoring.logging.LogMarkers;
 import se.inera.intyg.intygstjanst.web.service.MonitoringLogService;
 import se.inera.intyg.schemas.contract.Personnummer;
 

--- a/web/src/main/resources/logback-dev.xml
+++ b/web/src/main/resources/logback-dev.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Copyright (C) 2020 Inera AB (http://www.inera.se)
+  ~
+  ~ This file is part of sklintyg (https://github.com/sklintyg).
+  ~
+  ~ sklintyg is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ sklintyg is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<configuration>
+
+  <include resource="logback-dev-base.xml"/>
+
+
+  <logger name="org.apache.cxf" level="warn" />
+
+  <logger name="se.inera.intyg.intygstjanst.web.integration" level="info" />
+  <logger name="se.inera.intyg.intygstjanst.web.service.impl.StatisticsServiceImpl" level="info" />
+  <logger name="se.inera.intyg.intygstjanst.web.service.MonitoringLogService" level="info" />
+
+
+  <root level="info">
+    <appender-ref ref="CONSOLE" />
+    <appender-ref ref="MONITORING" />
+    <appender-ref ref="VALIDATION" />
+  </root>
+
+</configuration>

--- a/web/src/main/resources/logback-dev.xml
+++ b/web/src/main/resources/logback-dev.xml
@@ -20,15 +20,15 @@
 
 <configuration>
 
-  <include resource="logback-dev-base.xml"/>
+  <property name="APP_NAME" value="${APP_NAME:-intygstjanst}"/>
 
+  <include resource="logback-dev-base.xml"/>
 
   <logger name="org.apache.cxf" level="warn" />
 
   <logger name="se.inera.intyg.intygstjanst.web.integration" level="info" />
   <logger name="se.inera.intyg.intygstjanst.web.service.impl.StatisticsServiceImpl" level="info" />
   <logger name="se.inera.intyg.intygstjanst.web.service.MonitoringLogService" level="info" />
-
 
   <root level="info">
     <appender-ref ref="CONSOLE" />

--- a/web/src/main/resources/logback-ocp.xml
+++ b/web/src/main/resources/logback-ocp.xml
@@ -24,16 +24,17 @@
 
     <include resource="logback-ocp-base.xml"/>
 
-    <logger name="org.apache.cxf" level="WARN" />
+    <logger name="se.inera.intyg.intygstjanst" level="warn" />
     <logger name="se.inera.intyg.intygstjanst.web.integration" level="info" />
     <logger name="se.inera.intyg.intygstjanst.web.service.impl.StatisticsServiceImpl" level="info" />
 
-    <logger name="se.inera.intyg.intygstjanst.web.service.MonitoringLogService" level="INFO" additivity="false">
+    <logger name="se.inera.intyg.intygstjanst.web.service.MonitoringLogService" level="info" additivity="false">
         <appender-ref ref="MONITORING" />
     </logger>
 
-    <root level="INFO">
+    <root level="WARN">
         <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="VALIDATION"/>
     </root>
 
 </configuration>

--- a/web/src/main/webapp/WEB-INF/web.xml
+++ b/web/src/main/webapp/WEB-INF/web.xml
@@ -84,7 +84,7 @@
 
   <!-- Listener for external logback configuration file -->
   <listener>
-      <listener-class>se.inera.intyg.common.util.logging.LogbackConfiguratorContextListener</listener-class>
+      <listener-class>se.inera.intyg.infra.monitoring.logging.LogbackConfiguratorContextListener</listener-class>
   </listener>
   <listener>
     <listener-class>org.springframework.web.context.ContextLoaderListener</listener-class>


### PR DESCRIPTION
Work on this jira was aimed at harmonization of logback usage across all applications and included actions in infra, common, intygsadmin, intygstjanst, logsender, minaintyg, privatlakarportal, rehabstod, statistik and webcert. Briefly, logging functionality was collected in infra/monitoring, a logback-dev file was introduced for use in dev-environment and logback-ocp files (in web/resources as a backup and in devops/openshift/test) was set to produce logging identical to current prod-logging.  A summary of all actions can be found in PRs in common and infra. 